### PR TITLE
add ignore annotations for application

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
+++ b/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
@@ -347,6 +347,7 @@ spec:
         - /metadata/annotations/
         - /spec/source/helm/valueFiles/0
         - /spec/source/helm/valueFiles/1
+        - /spec/source/helm/valueFiles/2
   destination:
     server: https://kubernetes.default.svc
   project: default

--- a/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
+++ b/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
@@ -345,9 +345,7 @@ spec:
         - /metadata/annotations/argocd-image-updater.argoproj.io~1loader.allow-tags
         - /metadata/annotations/argocd-image-updater.argoproj.io~1ec.allow-tags
         - /metadata/annotations/
-        - /spec/source/helm/valueFiles/0
         - /spec/source/helm/valueFiles/1
-        - /spec/source/helm/valueFiles/2
   destination:
     server: https://kubernetes.default.svc
   project: default

--- a/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
+++ b/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
@@ -337,6 +337,14 @@ metadata:
   name: sp-argo-vm
   namespace: argocd
 spec:
+  ignoreDifferences:
+    - kind: Application
+      group: argoproj.io
+      jsonPointers:
+        - /metadata/annotations/argocd-image-updater.argoproj.io~1mediator.allow-tags
+        - /metadata/annotations/argocd-image-updater.argoproj.io~1loader.allow-tags
+        - /metadata/annotations/argocd-image-updater.argoproj.io~1ec.allow-tags
+        - /metadata/annotations/
   destination:
     server: https://kubernetes.default.svc
   project: default

--- a/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
+++ b/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
@@ -345,6 +345,7 @@ spec:
         - /metadata/annotations/argocd-image-updater.argoproj.io~1loader.allow-tags
         - /metadata/annotations/argocd-image-updater.argoproj.io~1ec.allow-tags
         - /metadata/annotations/
+        - /spec/source/helm/valueFiles/
   destination:
     server: https://kubernetes.default.svc
   project: default

--- a/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
+++ b/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/k8s.yaml
@@ -345,7 +345,8 @@ spec:
         - /metadata/annotations/argocd-image-updater.argoproj.io~1loader.allow-tags
         - /metadata/annotations/argocd-image-updater.argoproj.io~1ec.allow-tags
         - /metadata/annotations/
-        - /spec/source/helm/valueFiles/
+        - /spec/source/helm/valueFiles/0
+        - /spec/source/helm/valueFiles/1
   destination:
     server: https://kubernetes.default.svc
   project: default


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `ignoreDifferences` field in the Kubernetes configuration, allowing specified annotations to be ignored during application state comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->