### PR TITLE
Bump argocd version

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/templates/k8s.yaml.tmpl
+++ b/tools/osbuilder/rootfs-builder/ubuntu/superprotocol/templates/k8s.yaml.tmpl
@@ -162,8 +162,8 @@ spec:
     global:
       image:
         #tag: quay.io/argoproj/argocd:v2.12.4
-        tag: v2.12.4
-        digest: sha256:4fa3135b836a32c1b366375c6697cddbe279cb6fc315acb11a5395c300f23967
+        tag: v2.14.11
+        #digest: sha256:4fa3135b836a32c1b366375c6697cddbe279cb6fc315acb11a5395c300f23967
     redis:
       image:
         #tag: public.ecr.aws/docker/library/redis:7.2.4-alpine


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Argo CD image to version v2.14.11.
  - Disabled fixed digest pinning for the Argo CD image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->